### PR TITLE
notification dropdown to top

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -57,6 +57,7 @@
     min-width: 280px;
     padding: 0;
     border: 0;
+    z-index: 1041;
 
     h2 {
       font-size: $h5-font-size;


### PR DESCRIPTION
#22118

Pull Request for Issue # .

### Summary of Changes
Will cause notifications to be above the headers.


### Testing Instructions
go to extension manager click on notification bell in top right.
drop down will be obscured by header.
install patch
now drop down will be above the header.


### Expected result
![after](https://user-images.githubusercontent.com/1850089/45565051-0f497b80-b818-11e8-9d36-03d4c306f2ee.png)


### Actual result
![before](https://user-images.githubusercontent.com/1850089/45565041-048ee680-b818-11e8-8ce7-e83ad12dcd68.png)



### Documentation Changes Required
none
