### PR TITLE
Add missing fas class for quickicons

### DIFF
--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -174,6 +174,7 @@
       color: $danger-txt;
 
       .fa,
+      .fas,
       .fab {
         color: $danger-txt;
       }
@@ -183,6 +184,7 @@
         color: var(--white);
 
         .fa,
+        .fas,
         .fab {
           &::before {
             color: var(--white);
@@ -196,6 +198,7 @@
       border: 1px solid lighten($success-txt, 20%);
 
       .fa,
+      .fas,
       .fab {
         color: var(--success);
       }
@@ -205,6 +208,7 @@
         color: var(--white);
 
         .fa,
+        .fas,
         .fab {
           &::before {
             color: var(--white);

--- a/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
@@ -69,6 +69,8 @@
     }
 
     .inactive .fa,
+    .inactive .fas,
+    .inactive .fab,
     .inactive [class^=icon-] {
       color: $gray-400;
     }


### PR DESCRIPTION
Pull Request for [https://github.com/joomla/joomla-cms/pull/27657#issuecomment-581023613](https://github.com/joomla/joomla-cms/pull/27657#issuecomment-581023613).

### Summary of Changes

Adds missing "fas" classes to `administrator/templates/atum/scss/blocks/_quickicons.scss` and "fas" and "fab" to `administrator/templates/atum/scss/vendor/bootstrap/_table.scss`. For the latter change I haven't found where to see it in UI, I've found that by code review.

### Testing Instructions

See [https://github.com/joomla/joomla-cms/pull/27657#issuecomment-581023613](https://github.com/joomla/joomla-cms/pull/27657#issuecomment-581023613).

### Expected result

See [https://github.com/joomla/joomla-cms/pull/27657#issuecomment-581023613](https://github.com/joomla/joomla-cms/pull/27657#issuecomment-581023613).


### Actual result

See [https://github.com/joomla/joomla-cms/pull/27657#issuecomment-581023613](https://github.com/joomla/joomla-cms/pull/27657#issuecomment-581023613).


### Documentation Changes Required

None.